### PR TITLE
Add corporate certificate login button

### DIFF
--- a/login.md
+++ b/login.md
@@ -15,5 +15,43 @@ title: 會員登入
       <label for="password">密碼</label>
     </div>
     <button type="submit" class="btn waves-effect">登入</button>
+    <button id="corp-cert-login" type="button" class="btn waves-effect" style="margin-left: 1rem;">工商憑證登入</button>
   </form>
+  <div id="cert-modal" class="modal">
+    <div class="modal-content">
+      <h4>工商憑證資訊</h4>
+      <pre id="cert-data"></pre>
+    </div>
+    <div class="modal-footer">
+      <a href="#!" class="modal-close waves-effect btn-flat">關閉</a>
+    </div>
+  </div>
 </div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var btn = document.getElementById('corp-cert-login');
+    var modalElem = document.getElementById('cert-modal');
+    var certDataElem = document.getElementById('cert-data');
+    if (btn) {
+      btn.addEventListener('click', function() {
+        fetch('http://127.0.0.1:61161/pkcs11info?withcert=true')
+          .then(function(resp) { return resp.text(); })
+          .then(function(text) {
+            if (certDataElem) {
+              certDataElem.textContent = text;
+            }
+            var instance = M.Modal.getInstance(modalElem);
+            instance.open();
+          })
+          .catch(function(err) {
+            if (certDataElem) {
+              certDataElem.textContent = '無法取得憑證資訊';
+            }
+            var instance = M.Modal.getInstance(modalElem);
+            instance.open();
+          });
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- add a button for corporate certificate login on the login page
- fetch certificate information from the local PKCS#11 service and show it in a modal

## Testing
- `jekyll build` *(fails: command not found)*