### PR TITLE
Switch site to pastel green theme

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,8 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
   <style>
     :root {
-      --primary-color: #87CEEB; /* sky blue */
+      /* 使用粉綠色作為網站主色 */
+      --primary-color: #a8e6cf;
     }
     .section { padding-top: 4rem; padding-bottom: 4rem; }
     #cookie-consent {
@@ -25,6 +26,9 @@
     nav,
     .page-footer { background-color: var(--primary-color); }
     .primary-text { color: var(--primary-color); }
+    .btn,
+    .btn:hover,
+    .btn-floating { background-color: var(--primary-color); }
   </style>
 </head>
 <body>
@@ -59,7 +63,7 @@
   <div id="cookie-consent" class="grey lighten-4">
     <div class="container">
       本網站使用 cookie 以提升使用體驗。更多資訊請參閱 <a href="/privacy-policy.html">隱私政策</a>。
-      <a id="cookie-consent-accept" class="btn waves-effect blue" style="margin-left: 1rem;">我同意</a>
+      <a id="cookie-consent-accept" class="btn waves-effect" style="margin-left: 1rem;">我同意</a>
     </div>
   </div>
   <div id="notification-center" class="modal">
@@ -72,7 +76,7 @@
     </div>
   </div>
   <div class="fixed-action-btn">
-    <a id="notification-btn" class="btn-floating btn-large red">
+    <a id="notification-btn" class="btn-floating btn-large">
       <i class="large material-icons">notifications</i>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- use pastel green variable instead of sky blue
- ensure buttons and floating action button also use the primary color
- remove explicit Materialize color classes

## Testing
- `jekyll -v` *(fails: command not found)*